### PR TITLE
docs: add schedule docs + rename preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 A series of configurations and presets for [Renovate] dependency updates bot
 
+## Schedules
+
+### Why is this needed?
+
+Renovate allows [scheduling dependency updates](https://docs.renovatebot.com/key-concepts/scheduling/). However, specifying a period when Renovate can start dependency updates is not so easy:
+
+- **Renovate Mend App**: if not self-hosting Renovate, the cloud app will run [from time to time](https://docs.renovatebot.com/known-limitations/#the-mend-renovate-app-and-scheduled-jobs) and see if it's the right moment to do dependency updates based on the configuration. So the schedule you define must take this into account.
+- **Schedule syntax**: at the moment of writing specified via a `cron` or via a string to be parsed with `@breejs/later` library. `cron` lines are not very straight-forward to parse as humans. With the latter, despite more human, can be prone to error. Library may fail to parse it, and [Renovate will reject it if it fails to parse it](https://github.com/renovatebot/renovate/blob/32.241.11/lib/workers/repository/update/branch/schedule.ts#L55-L59). Also specifying it in this more human-friendly syntax [will be deprecated](https://docs.renovatebot.com/key-concepts/scheduling/#deprecated-breejslater-syntax)
+
+Therefore, sharing here some presets that may be useful. They are tested to ensure they behave as expected.
+
+## Usage
+
+### First weekend of the month. During the day.
+
+This will schedule your updates for the first weekend of every month. Saturday and Sunday. Will skip dependency updates at night so you can have sweet dreams. To use it:
+
+```json
+{
+  "extends": [
+    "github>davidlj95/renovate-config:schedule/first-weekend-month-day"
+  ]
+}
+```
+
 ## Angular
 
 ### Why is this needed?

--- a/schedule.json
+++ b/schedule.json
@@ -1,6 +1,6 @@
 {
-  "first-weekend-month-morning": {
-    "description": "Schedule updates every first weekend's day of the month at morning",
+  "first-weekend-month-day": {
+    "description": "Schedule updates every first weekend's day of the month during the day",
     "schedule": "on the 1-7 day of the month on Saturday,Sunday after 9:00 am"
   }
 }

--- a/test/schedule.test.js
+++ b/test/schedule.test.js
@@ -40,13 +40,13 @@ describe("Schedule", () => {
     });
   });
 
-  describe("first weekend month morning schedule", () => {
+  describe("first weekend month day schedule", () => {
     const fifteenthOfFebruary2025 = Date.parse("2025-02-15T00:00:00.000Z");
     const MORNING_TIME = "09:00:00.000";
     const MIDNIGHT_TIME = "00:00:00.000";
     const nextRanges = later
       .schedule(
-        later.parse.text(SCHEDULE_JSON["first-weekend-month-morning"].schedule),
+        later.parse.text(SCHEDULE_JSON["first-weekend-month-day"].schedule),
       )
       .nextRange(3, fifteenthOfFebruary2025);
     const [saturdayRange, sundayRange, nextRange] = nextRanges;


### PR DESCRIPTION
Adds docs for the recently added schedule preset. Change the name, given the relevant part is that schedule skips the night. Not that it starts at morning (consequence of skipping the night)
