### PR TITLE
refactor: use cron for schedules

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "node --test"
   },
   "devDependencies": {
-    "@breejs/later": "4.2.0",
+    "@cheap-glitch/mi-cron": "2.0.0",
     "prettier": "3.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,18 +8,17 @@ importers:
 
   .:
     devDependencies:
-      '@breejs/later':
-        specifier: 4.2.0
-        version: 4.2.0
+      '@cheap-glitch/mi-cron':
+        specifier: 2.0.0
+        version: 2.0.0
       prettier:
         specifier: 3.2.5
         version: 3.2.5
 
 packages:
 
-  '@breejs/later@4.2.0':
-    resolution: {integrity: sha512-EVMD0SgJtOuFeg0lAVbCwa+qeTKILb87jqvLyUtQswGD9+ce2nB52Y5zbTF1Hc0MDFfbydcMcxb47jSdhikVHA==}
-    engines: {node: '>= 10'}
+  '@cheap-glitch/mi-cron@2.0.0':
+    resolution: {integrity: sha512-HtpMH36PLzs7ZMJYaMWz32+4JOKeZHgzd2ms7vX0AdZmxZCu3MlASo+PoWkQaO9vT4ust7AS3j1hG783uxbiyA==}
 
   prettier@3.2.5:
     resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
@@ -28,6 +27,6 @@ packages:
 
 snapshots:
 
-  '@breejs/later@4.2.0': {}
+  '@cheap-glitch/mi-cron@2.0.0': {}
 
   prettier@3.2.5: {}

--- a/schedule.json
+++ b/schedule.json
@@ -1,6 +1,6 @@
 {
   "first-weekend-month-day": {
     "description": "Schedule updates every first weekend's day of the month during the day",
-    "schedule": "on the 1-7 day of the month on Saturday,Sunday after 9:00 am"
+    "schedule": "* 9-23 1-7 * 0,6"
   }
 }

--- a/test/schedule.test.js
+++ b/test/schedule.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import SCHEDULE_JSON from "../schedule.json" with { type: "json" };
-import later from "@breejs/later";
-import { strictEqual, ok } from "node:assert";
+import { parseCron } from "@cheap-glitch/mi-cron";
+import { notStrictEqual, ok } from "node:assert";
 
 describe("Schedule", () => {
   const scheduleTexts = Object.entries(SCHEDULE_JSON).map(([name, config]) => [
@@ -11,91 +11,16 @@ describe("Schedule", () => {
 
   scheduleTexts.forEach(([name, scheduleText]) => {
     describe(`"${name}" schedule`, () => {
-      const parsedSchedule = later.parse.text(scheduleText);
+      const parsedSchedule = parseCron(scheduleText);
 
-      // https://github.com/renovatebot/renovate/blob/32.241.11/lib/workers/repository/update/branch/schedule.ts#L55-L59
-      it(`should be error-free when parsing it with later tool`, () => {
-        const errorIndex = parsedSchedule.error;
-        strictEqual(
-          errorIndex,
-          -1,
-          `Error found when parsing schedule at position ${errorIndex}: '${aroundText(scheduleText, errorIndex)}'`,
+      // https://github.com/renovatebot/renovate/blob/32.241.11/lib/workers/repository/update/branch/schedule.ts#L36-L48
+      it(`should be a valid cron with no minute specificity`, () => {
+        notStrictEqual(parsedSchedule, undefined, "Schedule cannot be parsed");
+        ok(
+          parsedSchedule.minutes === 60 || scheduleText.indexOf("*") === 0,
+          "Cron should not specify a minute",
         );
       });
-
-      // https://docs.renovatebot.com/known-limitations/#the-mend-renovate-app-and-scheduled-jobs
-      // Otherwise it won't almost ever run. Because Renovate Mend App checks from time to time if it needs to run.
-      // If the schedule is for a specific second, in order for Renovate to run, it should check if it should run at
-      // that specific second. So pragmatically very difficult. Using after/before (`t_a`/`t_b`) should be used instead.
-      // https://github.com/renovatebot/renovate/blob/32.241.11/lib/workers/repository/update/branch/schedule.ts#L64-L68
-      it("should not define a specific time", () => {
-        parsedSchedule.schedules.forEach((schedule, index) => {
-          ok(
-            // https://breejs.github.io/later/time-periods.html#time
-            !Object.keys(schedule).includes("t"),
-            `Schedule ${index} has a specific time`,
-          );
-        });
-      });
-    });
-  });
-
-  describe("first weekend month day schedule", () => {
-    const fifteenthOfFebruary2025 = Date.parse("2025-02-15T00:00:00.000Z");
-    const MORNING_TIME = "09:00:00.000";
-    const MIDNIGHT_TIME = "00:00:00.000";
-    const nextRanges = later
-      .schedule(
-        later.parse.text(SCHEDULE_JSON["first-weekend-month-day"].schedule),
-      )
-      .nextRange(3, fifteenthOfFebruary2025);
-    const [saturdayRange, sundayRange, nextRange] = nextRanges;
-
-    it("should start on first saturday of the month's morning until midnight", () => {
-      const [saturdayRangeStart, saturdayRangeEnd] = saturdayRange;
-      strictEqual(
-        saturdayRangeStart.toISOString(),
-        `2025-03-01T${MORNING_TIME}Z`,
-        "Start date is wrong",
-      );
-      strictEqual(
-        saturdayRangeEnd.toISOString(),
-        `2025-03-02T${MIDNIGHT_TIME}Z`,
-        "End date is wrong",
-      );
-    });
-
-    it("should continue on first sunday of the month's morning until midnight", () => {
-      const [sundayRangeStart, sundayRangeEnd] = sundayRange;
-      strictEqual(
-        sundayRangeStart.toISOString(),
-        `2025-03-02T${MORNING_TIME}Z`,
-        "Start date is wrong",
-      );
-      strictEqual(
-        sundayRangeEnd.toISOString(),
-        `2025-03-03T${MIDNIGHT_TIME}Z`,
-        "End date is wrong",
-      );
-    });
-
-    it("should not repeat until next month's saturday", () => {
-      const [nextRangeStart] = nextRange;
-      strictEqual(
-        nextRangeStart.toISOString(),
-        `2025-04-05T${MORNING_TIME}Z`,
-        "Next range start is wrong",
-      );
     });
   });
 });
-
-const CHARS_AROUND = 5;
-const aroundText = (text, position) => {
-  const start = Math.max(0, position - CHARS_AROUND);
-  const end = Math.min(text.length, position + CHARS_AROUND + 1);
-  const before = text.slice(start, position);
-  const char = text[position];
-  const after = text.slice(position + 1, end);
-  return `${before}[${char}]${after}`;
-};


### PR DESCRIPTION
As `later` will be deprecated. So moving to Cron.
